### PR TITLE
fix envdir to substitute {homedir}, {toxworkdir} properly.

### DIFF
--- a/workspace/commands/helpers.py
+++ b/workspace/commands/helpers.py
@@ -59,11 +59,13 @@ class ToxIni(LocalConfig):
         return 'testenv:%s' % env if env else 'testenv'
 
     @property
+    def toxinidir(self):
+        return self.path
+
+    @property
     def workdir(self):
-        toxworkdir = self.get('tox', 'toxworkdir', '.tox')
-        toxworkdir = toxworkdir.replace('{homedir}', self.homedir)
-        toxworkdir = toxworkdir.replace('{toxinidir}', self.path)
-        return os.path.join(self.path, toxworkdir)
+        toxworkdir = self.get('tox', 'toxworkdir', '{toxinidir}/.tox')
+        return self.expand_vars(toxworkdir)
 
     @property
     def homedir(self):

--- a/workspace/commands/helpers.py
+++ b/workspace/commands/helpers.py
@@ -60,17 +60,23 @@ class ToxIni(LocalConfig):
 
     @property
     def workdir(self):
-        return os.path.join(self.path, self.get('tox', 'toxworkdir', '.tox'))
+        toxworkdir = self.get('tox', 'toxworkdir', '.tox')
+        toxworkdir = toxworkdir.replace('{homedir}', self.homedir)
+        toxworkdir = toxworkdir.replace('{toxinidir}', self.path)
+        return os.path.join(self.path, toxworkdir)
 
     @property
     def homedir(self):
         return os.path.expanduser('~')
 
     def envdir(self, env):
-        default_envdir = os.path.join(self.path, '.tox', env)
-        return self.expand_vars(self.get(self.envsection(env), 'envdir', self.get(self.envsection(),
-                                         'envdir', default_envdir)).replace('{toxworkdir}', self.workdir),
-                                {'envname': env})
+        default_envdir = os.path.join('{toxworkdir}', env)
+        default_envsection = self.envsection()
+        default_envdir = self.get(default_envsection, 'envdir', default_envdir)
+        envsection = self.envsection(env)
+        envdir = self.get(envsection, 'envdir', default_envdir)
+        envdir = envdir.replace('{toxworkdir}', self.workdir)
+        return self.expand_vars(envdir, {'envname': env})
 
     def bindir(self, env, script=None):
         dir = os.path.join(self.envdir(env), 'bin')


### PR DESCRIPTION
e.g.

```
[tox]
envlist = py27,py3
toxworkdir = {homedir}/.virtualenvs/my-app

[testenv:py27]
basepython = python2.7

[testenv:py3]
basepython = python3
```